### PR TITLE
Update Console URL for Fairground

### DIFF
--- a/console_urls.py
+++ b/console_urls.py
@@ -2,7 +2,7 @@ import json
 import base64
 
 
-root_url = 'https://testnet.vega.trading'
+root_url = 'https://console.fairground.wtf'
 
 
 def view(root_url, view, **props):


### PR DESCRIPTION
Merge me when Console URL needs to be changed from `testnet.vega.trading` to `console.fairground.wtf`